### PR TITLE
feat: manejo de vencimientos y sugerencias de recetas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+.vscode/settings.json

--- a/nutrisense_agents/ai_companion/tools/react_tools.py
+++ b/nutrisense_agents/ai_companion/tools/react_tools.py
@@ -122,15 +122,24 @@ def get_user_inventory_tool(*, config: RunnableConfig):
     return st.get_user_inventory(user_uuid)
 
 @tool
-def check_expiring_ingredients_tool(*, config: RunnableConfig):
+def check_expiring_ingredients_tool(*, days_ahead: int = 0, days_behind: int = 0, config: RunnableConfig):
     """
-    Devuelve los ingredientes del inventario que vencen HOY.
-    Excluye ingredientes ya vencidos o que vencen después.
+    Consulta el inventario del usuario y devuelve ingredientes según su fecha de vencimiento.
+
+    - expired: vencidos en los últimos `days_behind` días.
+    - expiring_today: vencen exactamente hoy.
+    - expiring_soon: vencen en los próximos `days_ahead` días.
+
+    Ejemplos:
+    - "Qué alimentos vencen hoy?" → days_ahead=0, days_behind=0
+    - "Qué alimentos ya vencieron?" → days_ahead=0, days_behind=30
+    - "Qué alimentos vencen en 2 días?" → days_ahead=2, days_behind=0
     """
     user_uuid = config.get("configurable", {}).get("user_uuid")
     if not user_uuid:
         raise KeyError("user_uuid")
-    return st.get_ingredients_expiring_today(user_uuid)
+
+    return st.get_ingredients_expiry_range(user_uuid, days_ahead, days_behind)
 
 @tool
 def suggest_recipes_from_stock_tool(*, config: RunnableConfig):
@@ -154,6 +163,23 @@ def generate_shopping_list_tool(*, recipe_ids: list[int], config: RunnableConfig
         raise KeyError("user_uuid")
     return st.generate_shopping_list(user_uuid, recipe_ids)
 
+@tool
+def suggest_recipes_for_expiring_tool(*, days_ahead: int = 3, config: RunnableConfig):
+    """
+    Sugiere recetas priorizando los ingredientes que están por vencer en los próximos `days_ahead` días.
+    Ordena las recetas de forma que primero aparezcan las que usan ingredientes con fecha más próxima
+    y mayor porcentaje de coincidencia.
+
+    Args:
+        days_ahead (int): rango de días hacia adelante para considerar "por vencer".
+    """
+    user_uuid = config.get("configurable", {}).get("user_uuid")
+    if not user_uuid:
+        raise KeyError("user_uuid")
+
+    return st.get_suggested_recipes_by_expiring_ingredients(user_uuid, days_ahead)
+
+
 TOOLS = [
     add_planned_meal_tool,
     create_meal_plan_tool,
@@ -163,6 +189,7 @@ TOOLS = [
     get_user_inventory_tool,
     check_expiring_ingredients_tool,
     suggest_recipes_from_stock_tool,
-    generate_shopping_list_tool
+    generate_shopping_list_tool,
+    suggest_recipes_for_expiring_tool
 ]
 

--- a/nutrisense_agents/api/routes/inventory_route.py
+++ b/nutrisense_agents/api/routes/inventory_route.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Query, HTTPException, Body
-from nutrisense_agents.ai_companion.tools.react_tools import get_user_inventory_tool, check_expiring_ingredients_tool,suggest_recipes_from_stock_tool,generate_shopping_list_tool
+from nutrisense_agents.ai_companion.tools.react_tools import get_user_inventory_tool, check_expiring_ingredients_tool,suggest_recipes_from_stock_tool,generate_shopping_list_tool,suggest_recipes_for_expiring_tool
 from langchain_core.runnables import RunnableConfig
 from nutrisense_agents.ai_companion.schemas.tools_schemas.react_input_schemas import ShoppingListInput
 
@@ -18,17 +18,34 @@ def get_user_inventory_route(user_uuid: str = Query(...)):
 
 
 @router.get("/inventory/expiring")
-def get_expiring_ingredients(user_uuid: str = Query(...)):
+def get_expiring_ingredients(
+    user_uuid: str = Query(..., description="ID único del usuario"),
+    days_ahead: int = Query(0, description="Días hacia adelante para buscar próximos vencimientos"),
+    days_behind: int = Query(0, description="Días hacia atrás para buscar vencidos recientes")
+):
     """
-    Devuelve los ingredientes del inventario que vencen HOY.
+    Devuelve los ingredientes del inventario según la fecha de vencimiento.
+
+    - expired: vencidos en los últimos `days_behind` días.
+    - expiring_today: vencen exactamente hoy.
+    - expiring_soon: vencen en los próximos `days_ahead` días.
+
+    Ejemplos:
+    - Solo lo que vence hoy → days_ahead=0, days_behind=0
+    - Vencidos últimos 7 días → days_ahead=0, days_behind=7
+    - Próximos 3 días → days_ahead=3, days_behind=0
     """
     try:
         config = RunnableConfig(configurable={"user_uuid": user_uuid})
         return {
-            "expiring_ingredients": check_expiring_ingredients_tool.invoke(input={}, config=config)
+            "expiring_ingredients": check_expiring_ingredients_tool.invoke(
+                input={"days_ahead": days_ahead, "days_behind": days_behind},
+                config=config
+            )
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
     
 @router.get("/inventory/suggested_recipes")
 def get_suggested_recipes(user_uuid: str = Query(...)):
@@ -57,6 +74,28 @@ def get_shopping_list(
         return {
             "shopping_list": generate_shopping_list_tool.invoke(
                 input=body.model_dump(),
+                config=config
+            )
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    
+@router.get("/recipes/expiring")
+def get_recipes_for_expiring(
+    user_uuid: str = Query(..., description="ID único del usuario"),
+    days_ahead: int = Query(3, description="Días hacia adelante para considerar ingredientes por vencer")
+):
+    """
+    Devuelve recetas sugeridas en base a los ingredientes que vencen en los próximos `days_ahead` días.
+    Prioriza:
+    1. Ingredientes con fecha de vencimiento más próxima.
+    2. Recetas con mayor porcentaje de coincidencia de ingredientes por vencer.
+    """
+    try:
+        config = RunnableConfig(configurable={"user_uuid": user_uuid})
+        return {
+            "recipes": suggest_recipes_for_expiring_tool.invoke(
+                input={"days_ahead": days_ahead},
                 config=config
             )
         }

--- a/nutrisense_agents/db/supabase/supabasetool.py
+++ b/nutrisense_agents/db/supabase/supabasetool.py
@@ -730,17 +730,20 @@ class SupabaseTools:
             log.error(f"Error en get_user_inventory: {e}")
             return []
 
-    def get_ingredients_expiring_today(self, user_uuid: str) -> list:
+    def get_ingredients_expiry_range(self, user_uuid: str, days_ahead: int = 3, days_behind: int = 0) -> dict:
         """
-        Devuelve los ingredientes del inventario que vencen exactamente HOY.
-        Excluye ingredientes ya vencidos o que vencen más adelante.
+        Devuelve ingredientes del inventario agrupados en:
+        - expired: vencidos en los últimos `days_behind` días
+        - expiring_today: vencen exactamente hoy
+        - expiring_soon: vencen en los próximos `days_ahead` días
         """
         try:
             inventory = self.get_user_inventory(user_uuid)
 
             today = datetime.today().date()
 
-            result = []
+            result = {"expired": [], "expiring_today": [], "expiring_soon": []}
+            
             for item in inventory:
                 expiry_raw = item.get("expiry_date")
                 if not expiry_raw:
@@ -751,14 +754,20 @@ class SupabaseTools:
                 except ValueError:
                     continue
 
-                if expiry_date == today:
-                    result.append(item)
+                delta_days = (expiry_date - today).days
+
+                if delta_days < 0 and abs(delta_days) <= days_behind:
+                    result["expired"].append(item)
+                elif delta_days == 0:
+                    result["expiring_today"].append(item)
+                elif 0 < delta_days <= days_ahead:
+                    result["expiring_soon"].append(item)
 
             return result
 
         except Exception as e:
-            log.error(f"Error en get_ingredients_expiring_today: {e}")
-            return []
+            log.error(f"Error en get_ingredients_by_expiry_range: {e}")
+            return {"expired": [], "expiring_today": [], "expiring_soon": []}
 
     def get_suggested_recipes_by_inventory(self, user_uuid: str) -> list:
         """
@@ -913,4 +922,101 @@ class SupabaseTools:
 
         except Exception as e:
             log.error(f" Error en generate_shopping_list: {e}")
+            return []
+
+    def get_suggested_recipes_by_expiring_ingredients(self, user_uuid: str, days_ahead: int = 3) -> list:
+        """
+        Sugiere recetas usando ingredientes que vencen pronto (en `days_ahead` días).
+        Prioriza recetas que:
+        1. Usen ingredientes con fecha más próxima de vencimiento.
+        2. Tengan mayor porcentaje de match de ingredientes próximos a vencer.
+        """
+        try:
+            today = datetime.today().date()
+
+            # 1. Obtener inventario y filtrar por próximos a vencer
+            inventory = self.get_user_inventory(user_uuid)
+            expiring_items = []
+            for item in inventory:
+                expiry_raw = item.get("expiry_date")
+                if not expiry_raw:
+                    continue
+
+                try:
+                    expiry_date = datetime.strptime(expiry_raw[:10], "%Y-%m-%d").date()
+                except ValueError:
+                    continue
+
+                delta_days = (expiry_date - today).days
+                if 0 < delta_days <= days_ahead:
+                    expiring_items.append({
+                        "ingredient_id": item["ingredient_id"],
+                        "ingredient_name": item["name"],
+                        "expiry_date": expiry_date
+                    })
+
+            if not expiring_items:
+                return []
+
+            expiring_map = {i["ingredient_id"]: i for i in expiring_items}
+
+            # 2. Obtener todas las recetas y sus ingredientes
+            recipe_ingredients = (
+                self.sb.table("recipe_ingredients")
+                .select("recipe_id, ingredient_id, quantity, unit, recipes(title), ingredients(name)")
+                .execute()
+            ).data or []
+
+            # 3. Agrupar por receta
+            recipes_map = {}
+            for ri in recipe_ingredients:
+                recipe_id = ri["recipe_id"]
+                recipe_title = ri["recipes"]["title"]
+                ingredient_id = ri["ingredient_id"]
+                ingredient_name = ri["ingredients"]["name"]
+
+                if recipe_id not in recipes_map:
+                    recipes_map[recipe_id] = {
+                        "title": recipe_title,
+                        "ingredients": []
+                    }
+
+                recipes_map[recipe_id]["ingredients"].append({
+                    "ingredient_id": ingredient_id,
+                    "ingredient_name": ingredient_name
+                })
+
+            # 4. Calcular match solo con ingredientes que vencen pronto
+            suggested = []
+            for recipe_id, recipe in recipes_map.items():
+                total_expiring_ingredients = len(expiring_items)
+                matching_expiring = [
+                    ing for ing in recipe["ingredients"]
+                    if ing["ingredient_id"] in expiring_map
+                ]
+
+                if not matching_expiring:
+                    continue  # Saltar si la receta no usa ingredientes por vencer
+
+                match_percent = int((len(matching_expiring) / total_expiring_ingredients) * 100)
+
+                # Ordenar internamente por fecha de vencimiento más próxima
+                closest_expiry = min(
+                    expiring_map[ing["ingredient_id"]]["expiry_date"] for ing in matching_expiring
+                )
+
+                suggested.append({
+                    "title": recipe["title"],
+                    "match_percent": match_percent,
+                    "matching_expiring_ingredients": [ing["ingredient_name"] for ing in matching_expiring],
+                    "closest_expiry": closest_expiry.isoformat()
+                })
+
+            # 5. Orden final: primero por fecha más próxima, luego por % de match
+            suggested.sort(key=lambda x: (x["closest_expiry"], -x["match_percent"]))
+
+            return suggested
+
+        except Exception as e:
+            log.error(f"Error en get_suggested_recipes_by_expiring_ingredients: {e}")
             return []


### PR DESCRIPTION
# feat: manejo de vencimientos y sugerencias de recetas

## **Descripción del cambio**
Este PR implementa la gestión completa de vencimientos de ingredientes y la sugerencia de recetas priorizando aquellos que están próximos a expirar.

La nueva lógica permite:
- Consultar ingredientes vencidos, que vencen hoy o que vencerán en un rango configurable de días.
- Recomendar recetas que aprovechen ingredientes próximos a vencer, optimizando el uso del inventario.
- Ordenar las sugerencias por proximidad de vencimiento y porcentaje de coincidencia de ingredientes.

---

## **Cambios principales**
### **1. Funcionalidad de vencimientos**
- **Nueva función** `get_ingredients_by_expiry_range(user_uuid, days_ahead, days_behind)`:
  - `expired`: ingredientes vencidos en los últimos `days_behind` días.
  - `expiring_today`: ingredientes que vencen exactamente hoy.
  - `expiring_soon`: ingredientes que vencen en los próximos `days_ahead` días.
- **Tool** `check_expiring_ingredients_tool`:
  - Llama a la función anterior con parámetros dinámicos según la consulta del usuario.
  - Permite queries como "qué venció en los últimos 7 días" o "qué vence en 2 días".

---

### **2. Sugerencias de recetas**
- **Nueva función** `get_suggested_recipes_by_expiring_ingredients(user_uuid, days_ahead)`:
  - Busca recetas que utilicen ingredientes que vencen dentro de `days_ahead` días.
  - Prioriza:
    1. Ingredientes con fecha de vencimiento más próxima.
    2. Mayor porcentaje de coincidencia de ingredientes por vencer en la receta.
- **Tool** `suggest_recipes_for_expiring_tool`:
  - Expuesta para que el agente pueda llamar directamente y devolver recetas ordenadas.
  - Ideal para interacciones del chat que pidan aprovechar ingredientes próximos a expirar.

---

### **3. Endpoints API**
- **Nuevo endpoint** `/recipes/expiring`:
  - Retorna las sugerencias generadas por `suggest_recipes_for_expiring_tool`.
  - Parámetro `days_ahead` opcional, por defecto `3`.
- **Ajuste en** `/inventory/expiring`:
  - Ahora acepta `days_ahead` y `days_behind` como parámetros opcionales.

---

## **Ejemplos de interacción (Chat + Tools)**

| Consulta del usuario | Tool llamada | Parámetros | Respuesta esperada |
|----------------------|-------------|------------|--------------------|
| "Qué alimentos vencen hoy?" | `check_expiring_ingredients_tool` | `days_ahead=0, days_behind=0` | Lista de ingredientes que expiran hoy |
| "Mostrame recetas con lo que vence esta semana" | `suggest_recipes_for_expiring_tool` | `days_ahead=7` | Lista de recetas ordenadas por urgencia y match |
| "Qué venció en los últimos 5 días" | `check_expiring_ingredients_tool` | `days_ahead=0, days_behind=5` | Lista de ingredientes vencidos en ese rango |

---

## **Impacto**
- Permite prevenir desperdicio de alimentos.
- Mejora la experiencia de usuario al integrar vencimientos con recomendaciones útiles.
- Escalable: la lógica puede extenderse a alertas y notificaciones automáticas.

---

## **Checklist**
- [x] Funciones implementadas y testeadas en entorno local.
- [x] Endpoints documentados y probados en Swagger.
- [x] Tools disponibles para uso del agente en chat.
